### PR TITLE
Fix PDF storage paths for publications

### DIFF
--- a/app/Http/Controllers/UsuarioController.php
+++ b/app/Http/Controllers/UsuarioController.php
@@ -43,7 +43,7 @@ class UsuarioController extends Controller
         $usuario = new User();
         $usuario->name = $request->name;
         $usuario->email =$request->email;
-        $usuario->password=$request->password;
+        $usuario->password = Hash::make($request->password);
 
         $usuario->save();
         return redirect()->route('usuarios.index');

--- a/resources/views/admin/publicaciones/edit.blade.php
+++ b/resources/views/admin/publicaciones/edit.blade.php
@@ -181,4 +181,6 @@
             </form>
         </div>
     </div>
+
+    @include('admin.publicaciones._archivos', ['pub' => $pub, 'archivos' => $archivos])
 @endsection

--- a/resources/views/admin/publicaciones/show.blade.php
+++ b/resources/views/admin/publicaciones/show.blade.php
@@ -103,7 +103,25 @@
                     </h3>
                     @if ($archivoPrincipal)
                         @php
-                            $pdfLink = $archivoPrincipal->URL ?: $archivoPrincipal->PATH;
+                            $disk = $archivoPrincipal->DISK ?? 'public';
+                            $pdfLink = $archivoPrincipal->URL;
+
+                            if (!$pdfLink && $archivoPrincipal->PATH) {
+                                $candidate = ltrim($archivoPrincipal->PATH, '/');
+
+                                if (\Illuminate\Support\Str::startsWith($candidate, 'storage/')) {
+                                    $pdfLink = '/' . $candidate;
+                                } else {
+                                    if (\Illuminate\Support\Str::startsWith($candidate, 'public/')) {
+                                        $candidate = \Illuminate\Support\Str::after($candidate, 'public/');
+                                    }
+
+                                    if ($candidate) {
+                                        $pdfLink = \Illuminate\Support\Facades\Storage::disk($disk)->url($candidate);
+                                    }
+                                }
+                            }
+
                             $tam = $archivoPrincipal->SIZE_BYTES
                                 ? number_format($archivoPrincipal->SIZE_BYTES / 1024, 1) . ' KB'
                                 : '—';

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\ArchivoPublicacionController;
 use App\Http\Controllers\PublicacionController;
 use App\Http\Controllers\UsuarioController;
 use App\Http\Controllers\InvestigadorController;
@@ -10,10 +11,6 @@ use Illuminate\Support\Facades\Route;
 //Route::get('/', function () {
 //  return view('welcome');
 //});
-
-Auth::routes();
-
-Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
 
 Auth::routes();
 
@@ -42,17 +39,19 @@ Route::put('/admin/usuarios/{usuario}', [UsuarioController::class, 'update'])->n
 
 //RUTAS EN GENERAL 
 Route::middleware('auth')->prefix('admin')->group(function () {
-    Route::resource('publicaciones', PublicacionController::class)
-        ->names('publicaciones')
-        ->parameters(['publicaciones' => 'id']); // opcional: para que sea /publicaciones/{id}
-
-});
-
-Route::middleware('auth')->prefix('admin')->group(function () {
     // PUBLICACIONES
     Route::resource('publicaciones', PublicacionController::class)
         ->names('publicaciones')
         ->parameters(['publicaciones' => 'id']); // => /admin/publicaciones/{id}
+
+    Route::post('publicaciones/{publicacion}/archivos', [ArchivoPublicacionController::class, 'store'])
+        ->name('publicaciones.archivos.store');
+
+    Route::delete('publicaciones/{publicacion}/archivos/{archivo}', [ArchivoPublicacionController::class, 'destroy'])
+        ->name('publicaciones.archivos.destroy');
+
+    Route::patch('publicaciones/{publicacion}/archivos/{archivo}/principal', [ArchivoPublicacionController::class, 'setPrincipal'])
+        ->name('publicaciones.archivos.principal');
 
     // INVESTIGADORES
     Route::resource('investigadores', InvestigadorController::class)


### PR DESCRIPTION
## Summary
- store publication PDFs on the public filesystem with consistent path, URL, and hash metadata
- expose publication file management via a reusable Blade partial and dedicated archivo routes
- hash user passwords on creation and improve file link fallbacks when displaying PDFs

## Testing
- `php artisan route:list` *(fails: vendor/autoload.php is absent in the repository)*

------
https://chatgpt.com/codex/tasks/task_b_68cc42074480832eadf32993033bde71